### PR TITLE
Fix: pynput backend on OSX (#36), and input handling on Windows

### DIFF
--- a/kvm_serial/backend/implementations/pynputop.py
+++ b/kvm_serial/backend/implementations/pynputop.py
@@ -135,6 +135,17 @@ class PynputOp(BaseOp):
         :param key:
         :return:
         """
+        # Some exit conditions must be checked BEFORE processing/sending the key
+        # On Windows, Ctrl+C may deliver '\x03' directly without Ctrl in modifier_map
+        try:
+            # If we received a raw ETX control character (Ctrl+C on Windows)
+            # then release all keys (avoids sticky Ctrl!) and exit
+            if key.char == "\x03":  # type: ignore[attr-defined]
+                self.hid_serial_out.release()
+                raise Listener.StopException()
+        except AttributeError:
+            pass
+
         scancode = [b for b in b"\x00" * 8]
 
         try:

--- a/kvm_serial/control.py
+++ b/kvm_serial/control.py
@@ -10,9 +10,11 @@ import platform
 # the project root is on sys.path so that `kvm_serial.*` imports resolve.
 try:
     from importlib import import_module
+
     import_module("kvm_serial.backend")
 except ModuleNotFoundError:
     import os
+
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from serial import Serial
@@ -202,6 +204,7 @@ def main():
     finally:
         stop_threads()  # Stop remaining threads (if running)
         logging.info("Exiting. Bye!")
+        logging.shutdown()  # Flush and close all handlers before exit
 
 
 if __name__ == "__main__":

--- a/tests/backend/implementations/test_pynputop.py
+++ b/tests/backend/implementations/test_pynputop.py
@@ -238,6 +238,19 @@ class TestPynputOperation:
                 op.on_press(key_maps["nonalpha_keys"]["esc"])
                 op.on_release(key_maps["nonalpha_keys"]["esc"])
 
+    def test_pynputop_exit_on_etx(self, op, sys_modules_patch):
+        """Windows delivers Ctrl+C as raw ETX ('\\x03') without populating
+        the modifier_map. on_press should release all keys and stop the listener."""
+        with patch.dict("sys.modules", sys_modules_patch):
+            from pynput.keyboard import Listener
+
+            with (
+                patch.object(Listener, "StopException", MockStopException),
+                pytest.raises(MockStopException),
+            ):
+                op.on_press(MockKeyCode(char="\x03"))
+            op.hid_serial_out.release.assert_called()
+
     def test_legacy_main_pynput(self, mock_serial, sys_modules_patch):
         """
         Test that main_pynput instantiates PynputOp, calls run, and returns None.


### PR DESCRIPTION
This PR fixes issue #36, and a bit more besides!

Primarily, the way that keymaps are set up in `pynputop.py` has been changed so that keys in the map are checked for existence at runtime against the actual values in Pynput's Key enum.

I've also improved keyboard event handling for Windows users, with a fix for handling Ctrl+C (ETX) keypresses in the `pynputop` backend on Windows, and a test for this scenario as it differs from how other platforms handle it. Windows users would be stuck inside the command line control program as Ctrl+C was not being handled.

**Keyboard Event Handling Improvements:**

* Updated `on_press` in `pynputop.py` to detect a raw ETX (`'\x03'`, typically Ctrl+C on Windows) and ensure all keys are released before stopping the listener. This prevents "sticky Ctrl" issues if Ctrl+C is sent without the modifier map being populated.

**Testing Enhancements:**

* Added `test_pynputop_exit_on_etx` to verify that receiving ETX triggers proper key release and listener termination, improving test coverage for Windows-specific behavior.

**Logging Improvements:**

* Ensured `logging.shutdown()` is called on exit in `control.py` to flush and close all log handlers, guaranteeing clean log output.